### PR TITLE
fix(atlas-core): control to prevent styling conflicts with older popup-menu versions

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_pop-up-menu.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_pop-up-menu.scss
@@ -30,24 +30,24 @@
         background-color: $bg-color;
         box-shadow: 0 2px 20px 1px rgba(5, 15, 129, 0.05), 0 2px 16px 0 rgba(33, 43, 54, 0.08);
 
-        &.popupmenu-position-left {
+        &.popupmenu-position-left:not(.popup-portal) {
             top: 0;
             left: 0;
             transform: translateX(-100%);
         }
 
-        &.popupmenu-position-right {
+        &.popupmenu-position-right:not(.popup-portal) {
             top: 0;
             right: 0;
             transform: translateX(100%);
         }
 
-        &.popupmenu-position-top {
+        &.popupmenu-position-top:not(.popup-portal) {
             top: 0;
             transform: translateY(-100%);
         }
 
-        &.popupmenu-position-bottom {
+        &.popupmenu-position-bottom:not(.popup-portal) {
             bottom: 0;
             transform: translateY(100%);
         }


### PR DESCRIPTION
This is the atlas part of the [PopupMenu PR](https://github.com/mendix/web-widgets/pull/29) , needs to be reviewed together due to className changes.