### PR TITLE
Use relative paths in web theme login files

### DIFF
--- a/packages/atlas/src/theme/web/login-with-mendixsso-automatically.html
+++ b/packages/atlas/src/theme/web/login-with-mendixsso-automatically.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <script>
-            self.location = "/openid/login" + window.location.search + window.location.hash;
+            self.location = "openid/login" + window.location.search + window.location.hash;
         </script>
     </head>
     <body>

--- a/packages/atlas/src/theme/web/login-with-mendixsso-button.html
+++ b/packages/atlas/src/theme/web/login-with-mendixsso-button.html
@@ -58,7 +58,7 @@
                             <hr />
                         </div>
 
-                        <a id="ssoButton" href="/openid/login" class="btn btn-default btn-lg">
+                        <a id="ssoButton" href="openid/login" class="btn btn-default btn-lg">
                             <img src="logo.png" />
                             <span class="loginpage-signin">Mendix Account</span>
                         </a>
@@ -66,7 +66,7 @@
                 </div>
             </div>
             <div class="loginpage-logo">
-                <img src="/logo.png" role="presentation" height="45" alt="" />
+                <img src="logo.png" role="presentation" height="45" alt="" />
             </div>
         </div>
 

--- a/packages/atlas/src/theme/web/login.html
+++ b/packages/atlas/src/theme/web/login.html
@@ -56,7 +56,7 @@
                 </div>
             </div>
             <div class="loginpage-logo">
-                <img src="/logo.png" role="presentation" height="45" alt="" />
+                <img src="logo.png" role="presentation" height="45" alt="" />
             </div>
         </div>
 


### PR DESCRIPTION
To be able to host Mendix apps on subpaths (e.g. https://example.com/nested/route/mendix-app) we need to replace the absolute paths with relatives. This MR modifies web theme login pages to always use relative urls for logos and requests.