### PR TITLE
Update _accordion.scss

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/core/helpers/_accordion.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/helpers/_accordion.scss
@@ -116,8 +116,7 @@
         }
 
         &.widget-accordion-striped {
-            > .widget-accordion-group:not(:is(.widget-accordion-brand-primary, .widget-accordion-brand-secondary, .widget-accordion-brand-success, .widget-accordion-brand-warning, .widget-accordion-brand-danger)):nth-child(2n
-                    + 1) {
+            > .widget-accordion-group:not(:is(.widget-accordion-brand-primary, .widget-accordion-brand-secondary, .widget-accordion-brand-success, .widget-accordion-brand-warning, .widget-accordion-brand-danger)):nth-child(odd) {
                 > .widget-accordion-group-header > .widget-accordion-group-header-button {
                     background-color: $accordion-bg-striped;
 


### PR DESCRIPTION
Replaced the (2n+1) with the (odd) CSS-selector for the nth-child within the 'widget-accordion-striped' declaration.

This has to be done in order for one of the JS libraries we implemented to properly parse the CSS (PagedJS).