### PR TITLE
Add focus state styling to PopupLayout close button

### DIFF
--- a/packages/atlas-core/CHANGELOG.md
+++ b/packages/atlas-core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## Added
+
+-   We added focus state styling to PopupLayout close button.
+
 ## [3.11.2] Atlas Core - 2023-7-21
 
 ### Fixed

--- a/packages/atlas-core/package.json
+++ b/packages/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2022. All rights reserved.",
   "repository": {

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_modal.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_modal.scss
@@ -36,6 +36,10 @@
                     /* For IE8 and earlier */
                     color: $modal-header-color;
                     text-shadow: none;
+                    &:focus {
+                        border-radius: 4px;
+                        outline: 2px solid $brand-primary;
+                    }
                 }
             }
 


### PR DESCRIPTION
The PopupLayout has missing styling for the close button we added a border styling to it's focus state.