### PR TITLE
[WC-2250] fix(atlas-core): add default padding for layoutgrid in react version

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-dojo.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-dojo.scss
@@ -69,15 +69,5 @@
     .mx-scrollcontainer .mx-placeholder {
         width: 100%;
         height: 100%;
-
-        .mx-layoutgrid,
-        .mx-layoutgrid-fluid {
-            @include layout-spacing($type: padding, $direction: all, $device: responsive);
-
-            .mx-layoutgrid,
-            .mx-layoutgrid-fluid {
-                padding: 0;
-            }
-        }
     }
 }

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-dojo.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-dojo.scss
@@ -69,5 +69,15 @@
     .mx-scrollcontainer .mx-placeholder {
         width: 100%;
         height: 100%;
+
+        .mx-layoutgrid,
+        .mx-layoutgrid-fluid {
+            @include layout-spacing($type: padding, $direction: all, $device: responsive);
+
+            .mx-layoutgrid,
+            .mx-layoutgrid-fluid {
+                padding: 0;
+            }
+        }
     }
 }

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
@@ -201,4 +201,16 @@
     .mx-scrollcontainer-slide.mx-scrollcontainer-open > .mx-scrollcontainer-toggleable {
         pointer-events: auto;
     }
+
+    .mx-scrollcontainer-center {
+        .mx-layoutgrid,
+        .mx-layoutgrid-fluid {
+            @include layout-spacing($type: padding, $direction: all, $device: responsive);
+
+            .mx-layoutgrid,
+            .mx-layoutgrid-fluid {
+                padding: 0;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix issue with default paddings in default atlas layout.