### PR TITLE
Update docker image to use dotnet instead of mono

### DIFF
--- a/scripts/mxbuild.Dockerfile
+++ b/scripts/mxbuild.Dockerfile
@@ -1,10 +1,10 @@
-FROM mono:6.12
+FROM mcr.microsoft.com/dotnet/runtime:6.0
 ARG MENDIX_VERSION
 
 RUN \
     echo "Installing Java..." && \
     apt-get -qq update && \
-    apt-get -qq install -y wget && \
+    apt-get -qq install -y wget libgdiplus && \
     wget -q https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -O /tmp/openjdk.tar.gz && \
     mkdir /usr/lib/jvm && \
     tar xfz /tmp/openjdk.tar.gz --directory /usr/lib/jvm && \
@@ -20,9 +20,9 @@ RUN \
     apt-get clean && \
 \
     echo "#!/bin/bash -x" >/bin/mxbuild && \
-    echo "mono /tmp/mxbuild/modeler/mxbuild.exe --java-home=/usr/lib/jvm/jdk-11.0.2 --java-exe-path=/usr/lib/jvm/jdk-11.0.2/bin/java \$@" >>/bin/mxbuild && \
+    echo "dotnet /tmp/mxbuild/modeler/mxbuild.dll --java-home=/usr/lib/jvm/jdk-11.0.2 --java-exe-path=/usr/lib/jvm/jdk-11.0.2/bin/java \$@" >>/bin/mxbuild && \
     chmod +x /bin/mxbuild && \
 \
     echo "#!/bin/bash -x" >/bin/mx && \
-    echo "mono /tmp/mxbuild/modeler/mx.exe \$@" >>/bin/mx && \
+    echo "dotnet /tmp/mxbuild/modeler/mx.dll \$@" >>/bin/mx && \
     chmod +x /bin/mx


### PR DESCRIPTION
Update docker image to use dotnet instead of mono in the release process automation.