### PR TITLE
Fix release for atlas web content

### DIFF
--- a/packages/atlas-content-native/package.json
+++ b/packages/atlas-content-native/package.json
@@ -14,7 +14,8 @@
   },
   "testProject": {
     "githubUrl": "https://github.com/mendix/native-mobile-resources",
-    "branchName": "main"
+    "branchName": "lts/9.24",
+    "mxVersion": "9.24.14.24569"
   },
   "scripts": {
     "release": "ts-node ./scripts/build.ts release",

--- a/packages/atlas-web-content/package.json
+++ b/packages/atlas-web-content/package.json
@@ -14,7 +14,7 @@
   },
   "testProject": {
     "githubUrl": "https://github.com/mendix/Atlas-Design-System",
-    "branchName": "main",
+    "branchName": "lts/9.24",
     "mxVersion": "10.5.0.21627"
   },
   "scripts": {

--- a/scripts/release/gh-release-atlas-core.js
+++ b/scripts/release/gh-release-atlas-core.js
@@ -94,12 +94,6 @@ async function updateTestProject(moduleInfo, testProject, tmp) {
         `echo ${moduleInfo.version} > themesource/${moduleInfo.moduleFolderNameInModeler}/.version`,
         testProject
     );
-    const gitOutput = await execShellCommand(`cd ${testProject} && git status`);
-    if (/nothing to commit/i.test(gitOutput)) {
-        console.warn(`Nothing to commit from repo ${testProject}`);
-    } else {
-        await execShellCommand("git add . && git commit -m 'Updated widgets and styling' && git push", testProject);
-    }
 }
 
 async function updateWidgetMpks(tmp, testProject) {

--- a/scripts/release/gh-release-atlas-core.js
+++ b/scripts/release/gh-release-atlas-core.js
@@ -75,7 +75,7 @@ async function updateTestProject(moduleInfo, testProject, tmp) {
     const tmpFolderStyles = join(testProject, `themesource/${moduleInfo.moduleFolderNameInModeler}`);
 
     console.log(`Updating project from ${moduleInfo.testProjectUrl}..`);
-    await cloneRepo(moduleInfo.testProjectUrl, testProject);
+    await cloneRepo(moduleInfo.testProjectUrl, testProject, moduleInfo.testProjectBranchName);
 
     console.log("Copying styling files and assets..");
 

--- a/scripts/release/gh-release-atlas-native.js
+++ b/scripts/release/gh-release-atlas-native.js
@@ -62,10 +62,4 @@ async function updateNativeComponentsTestProjectWithAtlas(moduleInfo, tmpFolder)
     const version = moduleInfo.version;
 
     await execShellCommand(`echo ${version} > themesource/${moduleInfo.moduleFolderNameInModeler}/.version`, tmpFolder);
-    const gitOutput = await execShellCommand(`cd ${tmpFolder} && git status`);
-    if (!/nothing to commit/i.test(gitOutput)) {
-        await execShellCommand("git add . && git commit -m 'Updated Atlas native styling' && git push", tmpFolder);
-    } else {
-        console.warn(`Nothing to commit from repo ${tmpFolder}`);
-    }
 }

--- a/scripts/release/gh-release-atlas-native.js
+++ b/scripts/release/gh-release-atlas-native.js
@@ -49,7 +49,7 @@ async function updateNativeComponentsTestProjectWithAtlas(moduleInfo, tmpFolder)
     const tmpFolderNativeStyles = join(tmpFolder, `themesource/${moduleInfo.moduleFolderNameInModeler}`);
 
     console.log("Updating NativeComponentsTestProject..");
-    await cloneRepo(moduleInfo.testProjectUrl, tmpFolder);
+    await cloneRepo(moduleInfo.testProjectUrl, testProject, moduleInfo.testProjectBranchName);
 
     console.log("Copying Native styling files..");
     await Promise.all([

--- a/scripts/release/gh-release-atlas-web-content.js
+++ b/scripts/release/gh-release-atlas-web-content.js
@@ -84,7 +84,7 @@ async function updateTestProject(moduleInfo, testProject, tmp) {
     const tmpFolderStyles = join(testProject, `themesource/${moduleInfo.moduleFolderNameInModeler}`);
 
     console.log(`Updating project from ${moduleInfo.testProjectUrl}..`);
-    await cloneRepo(moduleInfo.testProjectUrl, testProject);
+    await cloneRepo(moduleInfo.testProjectUrl, testProject, moduleInfo.testProjectBranchName);
 
     console.log("Copying styling files and assets..");
 
@@ -103,12 +103,6 @@ async function updateTestProject(moduleInfo, testProject, tmp) {
         `echo ${moduleInfo.version} > themesource/${moduleInfo.moduleFolderNameInModeler}/.version`,
         testProject
     );
-    const gitOutput = await execShellCommand(`cd ${testProject} && git status`);
-    if (/nothing to commit/i.test(gitOutput)) {
-        console.warn(`Nothing to commit from repo ${testProject}`);
-    } else {
-        await execShellCommand("git add . && git commit -m 'Updated widgets and styling' && git push", testProject);
-    }
 }
 
 async function updateWidgetMpks(tmp, testProject) {

--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -208,12 +208,12 @@ async function githubAuthentication(moduleInfo) {
     await execShellCommand(`echo "${process.env.GH_PAT}" | gh auth login --with-token`);
 }
 
-async function cloneRepo(githubUrl, localFolder) {
+async function cloneRepo(githubUrl, localFolder, githubBranch) {
     const githubUrlDomain = githubUrl.replace("https://", "");
     const githubUrlAuthenticated = `https://${process.env.GH_USERNAME}:${process.env.GH_PAT}@${githubUrlDomain}`;
     await rm(localFolder, { recursive: true, force: true });
     await mkdir(localFolder, { recursive: true });
-    await execShellCommand(`git clone ${githubUrlAuthenticated} ${localFolder}`);
+    await execShellCommand(`git clone --branch ${githubBranch} ${githubUrlAuthenticated} ${localFolder}`);
     await setLocalGitCredentials(localFolder);
 }
 

--- a/scripts/release/module-automation/commons.js
+++ b/scripts/release/module-automation/commons.js
@@ -83,7 +83,7 @@ async function createModuleMpkInDocker(sourceDir, moduleName, mendixVersion, exc
     const projectFile = basename((await getFiles(sourceDir, [`.mpr`]))[0]);
     await execShellCommand(
         `docker run -t -v ${sourceDir}:/source ` +
-            `--rm mxbuild:${mendixVersion} bash -c "mx update-widgets --loose-version-check /source/${projectFile} && dotnet /tmp/mxbuild/modeler/mx.dll create-module-package ${
+            `--rm mxbuild:${mendixVersion} bash -c "dotnet /tmp/mxbuild/modeler/mx.dll create-module-package ${
                 excludeFilesRegExp ? `--exclude-files='${excludeFilesRegExp}'` : ""
             } /source/${projectFile} ${moduleName}"`
     );


### PR DESCRIPTION
Since we're using the Atlas Design System project as a module export template, we started to have some errors because of the last release of the Atlas-Core and version 10.5. 

With this PR we're changing the base project used to be the branch lts/9.24. And also removed the GH commits in this project to avoid these errors in the future. And with this way is possible to use the main branch to keep the Atlas Design System updated with version 10.6 and to publish the reference app.