### PR TITLE
[MOO-1296]: Fix Icon Alignment in Floating Action Buttons

### DIFF
--- a/packages/atlas-core/CHANGELOG.md
+++ b/packages/atlas-core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We have fixed an issue where icons within Floating Action Buttons were not properly centered.
+
 ## [3.14.0] Atlas Core - 2024-1-25
 
 ### Changed

--- a/packages/atlas-core/package.json
+++ b/packages/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2024. All rights reserved.",
   "repository": {

--- a/packages/atlas/src/theme/native/custom-variables.ts
+++ b/packages/atlas/src/theme/native/custom-variables.ts
@@ -488,6 +488,13 @@ export const floatingActionButton: VariablesFloatingActionButton = {
         borderColor: brand.primary,
         backgroundColor: brand.primary
     },
+    buttonContainer: {
+        width: 50,
+        heigh: 50,
+        borderRadius: 25,
+        justifyContent: "center",
+        alignItems: "center"
+    },
     buttonIcon: {
         size: font.sizeLarge,
         color: contrast.lowest

--- a/packages/atlas/src/themesource/atlas_core/native/core/widgets/floatingactionbutton.ts
+++ b/packages/atlas/src/themesource/atlas_core/native/core/widgets/floatingactionbutton.ts
@@ -36,6 +36,14 @@ export const com_mendix_widget_native_floatingactionbutton_FloatingActionButton:
             height: 2
         }
     },
+    buttonContainer: {
+        // All ViewStyle properties are allowed
+        width: floatingActionButton.button.size,
+        height: floatingActionButton.button.size,
+        borderRadius: floatingActionButton.button.size / 2,
+        justifyContent: "center",
+        alignItems: "center"
+    },
     buttonIcon: {
         // Size and color are allowed
         size: floatingActionButton.buttonIcon.size,

--- a/packages/atlas/src/themesource/atlas_core/native/types/variables.d.ts
+++ b/packages/atlas/src/themesource/atlas_core/native/types/variables.d.ts
@@ -415,6 +415,13 @@ export interface VariablesFloatingActionButton {
         borderColor: string;
         backgroundColor: string;
     };
+    buttonContainer: {
+        heigh: number;
+        width: number;
+        borderRadius: number;
+        justifyContent: string;
+        alignItems: string;
+    };
     buttonIcon: {
         size: number;
         color: string;

--- a/packages/atlas/src/themesource/atlas_core/native/types/widgets.d.ts
+++ b/packages/atlas/src/themesource/atlas_core/native/types/widgets.d.ts
@@ -271,6 +271,7 @@ export interface FloatingActionButtonType {
     button?: ButtonStyleType & {
         rippleColor?: string;
     };
+    buttonContainer: ButtonStyleType;
     buttonIcon?: ButtonIconType;
     secondaryButton?: ButtonStyleType;
     secondaryButtonIcon?: ButtonIconType;

--- a/packages/atlas/src/themesource/atlas_core/native/variables.ts
+++ b/packages/atlas/src/themesource/atlas_core/native/variables.ts
@@ -501,6 +501,13 @@ let floatingActionButton: VariablesFloatingActionButton = {
         borderColor: brand.primary,
         backgroundColor: brand.primary
     },
+    buttonContainer: {
+        heigh: 50,
+        width: 50,
+        borderRadius: 25,
+        justifyContent: "center",
+        alignItems: "center"
+    },
     buttonIcon: {
         size: font.sizeLarge,
         color: contrast.lowest


### PR DESCRIPTION
This PR addresses an issue where the icons inside Floating Action Buttons (FABs) were not correctly centered, leading to a slight visual misalignment. The fix ensures that icons are now properly centered within the button, improving the overall aesthetic and consistency of our UI.