### PR TITLE
[WC-2355] fix for dojo in react client rendering

### DIFF
--- a/.github/workflows/AtlasVisualComparisonTest.yml
+++ b/.github/workflows/AtlasVisualComparisonTest.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+        run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list 
+          npx playwright install --with-deps chromium
       - name: Run Atlas test project
         run: npm run e2e
       - name: Run visual comparison tests

--- a/packages/atlas-core/CHANGELOG.md
+++ b/packages/atlas-core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed dataview footer's buttons not displaying properly if dojo widget is being put inside.
+
 ## [3.14.1] Atlas Core - 2024-4-4
 
 ### Fixed

--- a/packages/atlas-core/package.json
+++ b/packages/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.14.1",
+  "version": "3.14.2",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2024. All rights reserved.",
   "repository": {

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_data-view.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_data-view.scss
@@ -44,6 +44,13 @@
             }
         }
 
+        /* Fix for Dojo rendering in react client */
+        [id^="mxui_widget_Wrapper"]:has(> .mx-button) {
+            .mx-button {
+                margin-right: $spacing-small;
+            }
+        }
+
         background-color: inherit;
     }
 }


### PR DESCRIPTION
when buttons are rendered inside dataview's footer, buttons will have no margin if:
dataview contained dojo widget.

due to: last button margin should be : 0,
while being inside dojo, buttons will have extra div wrapper, which will considered it always as last-child selector.

this fix will be specifically patch for it.
(removing last-child selector)