### PR TITLE
Atlas Core: Import App custom-variables before the module own variables

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/main.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/main.scss
@@ -2,9 +2,9 @@
 @import "exclusion-variables-defaults";
 @import "../../../theme/web/exclusion-variables";
 @import "generated-exclusion-variables";
+@import "../../../theme/web/custom-variables";
 @import "variables";
 @import "variables-css-mappings";
-@import "../../../theme/web/custom-variables";
 
 // Font Family Import
 @if $font-family-import != false {


### PR DESCRIPTION
With this change, variables values set in `theme/web/custom-variables.scss` using the `!default` flag
would take precedence over the values in `themesource/atlas_core/web/_variables.scss` like the normal assignments.

<details>
<summary>Our use case</summary>

We use two UI Modules: 

1. Our Style System, created using the [tutorial](https://docs.mendix.com/howto/front-end/customize-styling-new/#create-theme-mod) in the docs, which we use in all our projects.
2. Branding modules for some of our clients, containing only their colors and logo images.

The 1<sup>st</sup> sets default values for the `$brand-` variables, which the 2<sup>nd</sup> overrides when imported first.
However when the 2<sup>nd</sup> module is not present, the values in the 1<sup>st</sup> are ignored because of the `!default` flag.

</details>