### PR TITLE
[WC-2546]: Fix atlas sidebar when using React Mode

### DIFF
--- a/packages/atlas-core/CHANGELOG.md
+++ b/packages/atlas-core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed sidebar menu when using app with react mode.
+
 ## [3.14.3] Atlas Core - 2024-7-31
 
 ### Fixed

--- a/packages/atlas-core/package.json
+++ b/packages/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.14.3",
+  "version": "3.14.4",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2024. All rights reserved.",
   "repository": {

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
@@ -132,7 +132,7 @@
     .mx-scrollcontainer-push:not(.mx-scrollcontainer-open) > .mx-scrollcontainer-toggleable,
     .mx-scrollcontainer-slide:not(.mx-scrollcontainer-open) > .mx-scrollcontainer-toggleable {
         flex-basis: var(--closed-sidebar-width, 0px);
-        overflow: clip;
+        overflow: hidden;
     }
 
     // For open sidebar - full width

--- a/packages/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/layouts/_layout-atlas-responsive.scss
@@ -26,7 +26,7 @@
                     &.mx-navigationtree-has-items:hover > ul {
                         position: absolute;
                         z-index: 100;
-                        top: 0;
+                        top: $topbar-minimalheight;
                         bottom: 0;
                         left: $sidebar-icon-width;
                         display: block;
@@ -34,6 +34,7 @@
                         padding: $spacing-small 0;
 
                         & > li.mx-navigationtree-has-items:hover > ul {
+                            top: 0;
                             left: 100%;
                         }
                     }


### PR DESCRIPTION
### Description
Fix atlas sidebar when react mode is enabled

Before fix:
![React only client enabled](https://github.com/user-attachments/assets/dfae21fe-4280-4eb7-99f3-f0096fcb0e28)

After fix:
![React only client disabled](https://github.com/user-attachments/assets/ddbfb12f-bec4-4314-a3ac-574e07d3e5fa)
