### PR TITLE
[WC-2670]: Move popup menu styles to atlas

### DIFF
--- a/packages/atlas-core/CHANGELOG.md
+++ b/packages/atlas-core/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 -   We added language translation for design properties.
+-   We added the styling of popup menu widget to atlas.
 
 ## [3.14.5] Atlas Core - 2024-10-2
 

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_pop-up-menu.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_pop-up-menu.scss
@@ -14,9 +14,11 @@
     .popupmenu {
         position: relative;
         display: inline-flex;
+        overflow: visible;
     }
 
     .popupmenu-trigger {
+        position: relative;
         cursor: pointer;
     }
 
@@ -63,6 +65,17 @@
             border-bottom-left-radius: 8px;
             border-bottom-right-radius: 8px;
         }
+    }
+
+    ul.popupmenu-menu {
+        display: flex;
+        list-style-type: none;
+        padding-inline-start: 0;
+        z-index: 1;
+    }
+
+    .table .td > .popupmenu {
+        overflow: visible;
     }
 
     .popupmenu-basic-divider {


### PR DESCRIPTION
Moving styles from the widget source to atlas.