### PR TITLE
Change focus to focus-visible to hide initial focus when modal is opened

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_modal.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_modal.scss
@@ -36,7 +36,7 @@
                     /* For IE8 and earlier */
                     color: $modal-header-color;
                     text-shadow: none;
-                    &:focus {
+                    &:focus-visible {
                         border-radius: 4px;
                         outline: 2px solid $brand-primary;
                     }


### PR DESCRIPTION
Changes focus to focus-visible on modal header. This prevents the focus border from being visible when modal is first opened but still allows a visible focus indicator when user uses keyboard input to navigate.