### PR TITLE
[WC-3010]fix: dataview content vertical scroll

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_data-view.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_data-view.scss
@@ -15,6 +15,7 @@
     .mx-dataview {
         display: flex;
         flex-direction: column;
+        overflow-y: auto;
         /* Dataview-content gives problems for nested layout grid containers */
         > .mx-dataview-content {
             flex-grow: 1;

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
@@ -223,16 +223,19 @@
         flex-direction: column;
 
         & > .mx-scrollcontainer-wrapper{
-            flex-grow: 1;
+            height: 100%;
+            flex: 1;
             display: flex;
             flex-direction: column;
 
             & > .mx-placeholder{
+                height: 100%;
                 flex-grow: 1;
                 display: flex;
                 flex-direction: column;
 
                 & > *:only-child{
+                    height: 100%;
                     flex-grow: 1;
                 }
             }


### PR DESCRIPTION
put vertical scroll bar on dataview content instead of the whole dataview in react mode.