### PR TITLE
[WC-3085] fix scroll container regions z-index issues [v3]

### DIFF
--- a/packages/atlas-core/CHANGELOG.md
+++ b/packages/atlas-core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with sidebar menu not overlaying some elements in modern client.
+
 ## [3.18.2] Atlas Core - 2025-8-7
 
 ### Fixed

--- a/packages/atlas-core/package.json
+++ b/packages/atlas-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlas-core",
   "moduleName": "Atlas Core",
-  "version": "3.18.2",
+  "version": "3.18.3",
   "license": "Apache-2.0",
   "copyright": "© Mendix Technology BV 2024. All rights reserved.",
   "repository": {

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_scroll-container-react.scss
@@ -192,6 +192,7 @@
         &:not(.mx-scrollcontainer-nested) {
             -webkit-overflow-scrolling: touch;
         }
+        isolation: isolate;
     }
 
     // for push aside and slide over the main part should be non-interactive if sidebar is open


### PR DESCRIPTION
This fix is meant to isolate scroll container regions from each other, this is needed to prevent z-index wars between elements in different regions.

With this change, every element in a scroll container region (no matter how high it's z-index is) won't compete with elements form other regions (and the region itself).