### PR TITLE
[UFC-1757] Remove deprecated PWA meta tag for login.html

### DIFF
--- a/packages/atlas/src/theme/web/login-with-mendixsso-button.html
+++ b/packages/atlas/src/theme/web/login-with-mendixsso-button.html
@@ -4,7 +4,6 @@
         <meta charset="utf-8" />
         <title>Login</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
 
         {{themecss}} {{appicons}} {{manifest}} {{startupimages}}
     </head>

--- a/packages/atlas/src/theme/web/login.html
+++ b/packages/atlas/src/theme/web/login.html
@@ -4,7 +4,6 @@
         <meta charset="utf-8" />
         <title>Login</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
 
         {{themecss}} {{appicons}} {{manifest}} {{startupimages}}
     </head>


### PR DESCRIPTION
Hi team,

On navigation to `login.html` in apps using the Atlas theme the following deprecation warning message is shown in the dev tools console:
```
<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">
```
This deprecated meta tag was used for Apple devices which used to not have proper support for the web app manifest. However, [as of iOS 11.3, proper support for it was added,]([Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest#browser_compatibility)) making this meta tag redundant.

I tested the change on my iPhone and I am still able to add a PWA to my homescreen in fullscreen mode.

This MR removes the tag for `login.html` and `login-with-mendixsso-button.html` to get rid of the warning.