### PR TITLE
[WC-2552] Switch: hidden input in Atlas 4

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_switch.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_switch.scss
@@ -149,23 +149,12 @@ $default-ios-color: rgb(100, 189, 99);
     }
 
     .widget-switch input[type="checkbox"].sr-only {
-        position: absolute;
+        position: absolute!important;
         width: 1px;
         height: 1px;
         padding: 0;
-        margin: -1px;
+        margin: -1px!important;
         overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        border: 0;
-    }
-    .widget-switch input[type="checkbox"].sr-only-focusable:active,
-    .widget-switch input[type="checkbox"].sr-only-focusable:focus {
-        position: static;
-        width: auto;
-        height: auto;
-        margin: 0;
-        overflow: visible;
-        clip: auto;
     }
 
     @include style("primary", var(--brand-primary));


### PR DESCRIPTION
Added more specific selector to hide input[type=checkbox].sr-only from the switch widget.

Related PR: https://github.com/mendix/web-widgets/pull/1870