### PR TITLE
[WC-3474] fix check box validation feedback width

### DIFF
--- a/packages/atlas-core/CHANGELOG.md
+++ b/packages/atlas-core/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where the validation feedback of the Check Box widget was not full width and its height depended on the label length.
+
 ## [4.3.7] Atlas Core - 2026-6-24
 
 ### Changed

--- a/packages/atlas/src/themesource/atlas_core/web/core/widgets/_check-box.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/core/widgets/_check-box.scss
@@ -13,6 +13,8 @@
     ========================================================================== */
 
     .mx-checkbox.label-after {
+        flex-wrap: wrap;
+
         .control-label {
             flex: 1;
             display: flex;


### PR DESCRIPTION
## Summary
- Check Box validation feedback was not consistently full width — its height depended on the label's length, unlike other inputs.
- Root cause: `.mx-checkbox.label-after` is a flex container without `flex-wrap`, so `.mx-validation-message`'s `flex-basis: 100%` couldn't force it onto its own row.
- Added `flex-wrap: wrap` to `.mx-checkbox.label-after` in `_check-box.scss`.

## Test plan
- [x] Verified in browser: validation message now renders full width with fixed height, independent of label length
- [x] Verified no-error state unaffected (no stray wrapping)
- [x] Confirmed no other widget shares this scss block (no regression surface)