### PR TITLE
Fix multiple :root CSS blocks 

### DIFF
--- a/packages/atlas/src/themesource/atlas_core/web/_color-variants.scss
+++ b/packages/atlas/src/themesource/atlas_core/web/_color-variants.scss
@@ -29,31 +29,38 @@ $lightness-steps: (
     900: -60%
 );
 
-// generate corresponding CSS variables
-:root {
-    @each $name, $bg-class, $text-class, $base-color in $brand-colors {
-        @each $shade, $adjustment in $lightness-steps {
-            --#{$name}-#{$shade}: #{adjust-color-lightness($base-color, $adjustment)};
-        }
+// Guard against duplicate :root emission when this file is imported repeatedly.
+$atlas-color-variants-root-emitted: false !default;
 
-        @if ($bg-class != "") {
-            .#{$bg-class} {
-                @each $shade, $adjustment in $lightness-steps {
-                    &.shade-#{$shade} {
-                        background-color: adjust-color-lightness($base-color, $adjustment);
+// generate corresponding CSS variables
+@if $atlas-color-variants-root-emitted == false {
+    :root {
+        @each $name, $bg-class, $text-class, $base-color in $brand-colors {
+            @each $shade, $adjustment in $lightness-steps {
+                --#{$name}-#{$shade}: #{adjust-color-lightness($base-color, $adjustment)};
+            }
+
+            @if ($bg-class != "") {
+                .#{$bg-class} {
+                    @each $shade, $adjustment in $lightness-steps {
+                        &.shade-#{$shade} {
+                            background-color: adjust-color-lightness($base-color, $adjustment);
+                        }
                     }
                 }
             }
-        }
 
-        @if ($text-class != "") {
-            .#{$text-class} {
-                @each $shade, $adjustment in $lightness-steps {
-                    &.shade-#{$shade} {
-                        color: adjust-color-lightness($base-color, $adjustment);
+            @if ($text-class != "") {
+                .#{$text-class} {
+                    @each $shade, $adjustment in $lightness-steps {
+                        &.shade-#{$shade} {
+                            color: adjust-color-lightness($base-color, $adjustment);
+                        }
                     }
                 }
             }
         }
     }
+
+    $atlas-color-variants-root-emitted: true !global;
 }


### PR DESCRIPTION
**Issue**:

Atlas Core `_color-variants.scss` file emits a `:root` CSS block multiple times—once per module—causing the compiled theme CSS to contain hundreds of duplicate `:root` blocks.

**Solution**:

Add a Sass guard so it emits `:root` only once.


Guard added in `_color-variants.scss:32`.
Conditional one-time emission starts at `_color-variants.scss:36`.
Global emitted flag set at `_color-variants.scss:65` .